### PR TITLE
Address golint warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,4 @@ require (
 	github.com/libp2p/go-libp2p v0.19.2
 	github.com/libp2p/go-libp2p-core v0.15.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f
 )

--- a/libp2pcarserver/server.go
+++ b/libp2pcarserver/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -69,7 +68,7 @@ func (l *Libp2pCARServer) serveCARFile(s network.Stream) {
 	_ = s.SetReadDeadline(time.Now().Add(readDeadline))
 	defer s.SetReadDeadline(time.Time{}) // nolint
 
-	reqBz, err := ioutil.ReadAll(io.LimitReader(s, network.MessageSizeMax))
+	reqBz, err := io.ReadAll(io.LimitReader(s, network.MessageSizeMax))
 	if err != nil {
 		return
 	}

--- a/libp2pcarserver/server.go
+++ b/libp2pcarserver/server.go
@@ -68,8 +68,8 @@ func (l *Libp2pCARServer) serveCARFile(s network.Stream) {
 	_ = s.SetReadDeadline(time.Now().Add(readDeadline))
 	defer s.SetReadDeadline(time.Time{}) // nolint
 
-	reqBz, err := io.ReadAll(io.LimitReader(s, network.MessageSizeMax))
-	if err != nil {
+	reqBz, reqErr := io.ReadAll(io.LimitReader(s, network.MessageSizeMax))
+	if reqErr != nil {
 		return
 	}
 
@@ -78,8 +78,8 @@ func (l *Libp2pCARServer) serveCARFile(s network.Stream) {
 	if err := json.Unmarshal(reqBz, &req); err != nil {
 		return
 	}
-	dr, err := carRequestToDAGRequest(&req)
-	if err != nil {
+	dr, drErr := carRequestToDAGRequest(&req)
+	if drErr != nil {
 		return
 	}
 	log.Debugw("car transfer request", "base64-root", req.Root, "base64-selector", req.Selector)
@@ -96,8 +96,7 @@ func (l *Libp2pCARServer) serveCARFile(s network.Stream) {
 		bf := bufio.NewWriter(s)
 		defer bf.Flush()
 
-		_, err = car.TraverseV1(l.ctx, &ls, dr.root, dr.selector, bf)
-		if err != nil {
+		if _, err := car.TraverseV1(l.ctx, &ls, dr.root, dr.selector, bf); err != nil {
 			return err
 		}
 		return nil

--- a/libp2pcarserver/server_test.go
+++ b/libp2pcarserver/server_test.go
@@ -54,17 +54,14 @@ func TestSimpleTransfer(t *testing.T) {
 	require.NoError(t, from.Close())
 	// add the car file to the car store
 	require.NoError(t, cs.Create(rts[0], rts[0], func(bs bstore.Blockstore) error {
-		f, err := os.Open("../testdata/files/sample-v1.car")
-		if err != nil {
+		f, fErr := os.Open("../testdata/files/sample-v1.car")
+		if fErr != nil {
 			return err
 		}
-		if _, err := car.LoadCar(ctx, bs, f); err != nil {
-			return err
+		if _, lErr := car.LoadCar(ctx, bs, f); lErr != nil {
+			return lErr
 		}
-		if err := f.Close(); err != nil {
-			return err
-		}
-		return nil
+		return f.Close()
 	}))
 
 	rtbz := rts[0].Bytes()

--- a/libp2pcarserver/server_test.go
+++ b/libp2pcarserver/server_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -82,12 +82,12 @@ func TestSimpleTransfer(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, s.CloseWrite())
 
-	resp, err := ioutil.ReadAll(s)
+	resp, err := io.ReadAll(s)
 	require.NoError(t, err)
 	require.NotEmpty(t, resp)
 
 	// ensure contents match
-	fbz, err := ioutil.ReadFile("../testdata/files/sample-v1.car")
+	fbz, err := os.ReadFile("../testdata/files/sample-v1.car")
 	require.NoError(t, err)
 	require.EqualValues(t, fbz, resp)
 }

--- a/libp2pcarserver/types.go
+++ b/libp2pcarserver/types.go
@@ -19,8 +19,8 @@ type CARTransferRequest struct {
 }
 
 type dagTraversalRequest struct {
-	root     cid.Cid
 	selector ipld.Node
+	root     cid.Cid
 }
 
 func carRequestToDAGRequest(req *CARTransferRequest) (*dagTraversalRequest, error) {

--- a/main/main.go
+++ b/main/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	address "github.com/filecoin-project/go-address"
 	"github.com/gorilla/mux"
@@ -58,18 +59,19 @@ func main() {
 		panic(err)
 	}
 
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
 		if err := srv.Serve(nl); err != http.ErrServerClosed {
 			panic(err)
 		}
+		wg.Done()
 	}()
 
 	port = nl.Addr().(*net.TCPAddr).Port
 	fmt.Println("Server listening on", nl.Addr())
 	fmt.Printf("WebUI: http://localhost:%d/webui\n", port)
-	for {
-
-	}
+	wg.Wait()
 }
 
 func webuiHandler(w http.ResponseWriter, r *http.Request) {

--- a/main/main.go
+++ b/main/main.go
@@ -29,7 +29,7 @@ func main() {
 		var err error
 		port, err = strconv.Atoi(portStr)
 		if err != nil {
-			panic(fmt.Errorf("Invalid PORT value '%s': %s", portStr, err.Error()))
+			panic(fmt.Errorf("invalid PORT value '%s': %s", portStr, err.Error()))
 		}
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -76,8 +76,8 @@ func webuiHandler(w http.ResponseWriter, r *http.Request) {
 	rootDir := "webui"
 	path := strings.TrimPrefix(r.URL.Path, "/")
 
-	_, err := resources.WebUI.Open(path)
-	if path == rootDir || os.IsNotExist(err) {
+	_, pathErr := resources.WebUI.Open(path)
+	if path == rootDir || os.IsNotExist(pathErr) {
 		// file does not exist, serve index.html
 		index, err := resources.WebUI.ReadFile(rootDir + "/index.html")
 		if err != nil {
@@ -88,8 +88,8 @@ func webuiHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(index)
 		return
-	} else if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	} else if pathErr != nil {
+		http.Error(w, pathErr.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -88,7 +88,9 @@ func webuiHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write(index)
+		if _, err := w.Write(index); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	} else if pathErr != nil {
 		http.Error(w, pathErr.Error(), http.StatusInternalServerError)
@@ -103,6 +105,8 @@ func configHandler(conf []byte) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		w.Write(conf)
+		if _, err := w.Write(conf); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 	}
 }

--- a/main/main.go
+++ b/main/main.go
@@ -58,6 +58,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer nl.Close()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -65,6 +66,7 @@ func main() {
 		if err := srv.Serve(nl); err != http.ErrServerClosed {
 			panic(err)
 		}
+		defer srv.Close()
 		wg.Done()
 	}()
 

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -2,7 +2,7 @@ package resources
 
 import "embed"
 
-// webui folder is empty during local development, embed resources.go
+// WebUI folder is empty during local development, embed resources.go
 // so go doesn't complain about "no embeddable files"
 //
 //go:embed webui resources.go

--- a/store/carstore.go
+++ b/store/carstore.go
@@ -16,11 +16,11 @@ import (
 type CarRef = cid.Cid
 
 type CARStore struct {
-	rootdir string
-	lk      sync.Mutex
-
 	writing map[CarRef]*blockstore.ReadWrite
 	open    map[CarRef]*blockstore.ReadOnly
+
+	rootdir string
+	lk      sync.Mutex
 }
 
 // Create a new CAR store roooted at the given directory.

--- a/store/carstore.go
+++ b/store/carstore.go
@@ -65,13 +65,13 @@ func (c *CARStore) Create(id CarRef, payloadCid cid.Cid, writer func(bstore.Bloc
 	}
 
 	path := c.pathFor(true, id)
-	bs, err := blockstore.OpenReadWrite(path, []cid.Cid{payloadCid}, blockstore.UseWholeCIDs(true))
-	if err != nil {
-		return fmt.Errorf("opening new rw store: %w", err)
+	bs, bsErr := blockstore.OpenReadWrite(path, []cid.Cid{payloadCid}, blockstore.UseWholeCIDs(true))
+	if bsErr != nil {
+		return fmt.Errorf("opening new rw store: %w", bsErr)
 	}
 
 	c.lk.Unlock()
-	err = writer(bs)
+	bsErr = writer(bs)
 	ferr := bs.Finalize()
 	c.lk.Lock()
 
@@ -79,11 +79,11 @@ func (c *CARStore) Create(id CarRef, payloadCid cid.Cid, writer func(bstore.Bloc
 		return fmt.Errorf("finalize store: %w", ferr)
 	}
 
-	if err != nil {
+	if bsErr != nil {
 		if err := os.Remove(path); err != nil {
 			return fmt.Errorf("cleaning up old temp store: %w", err)
 		}
-		return fmt.Errorf("calling car writer: %w", err)
+		return fmt.Errorf("calling car writer: %w", bsErr)
 	}
 
 	delete(c.writing, id)


### PR DESCRIPTION
As I was familiarising myself with the codebase, I noticed a couple of warnings which could be addressed. I ended up doing just that.

- Tackled staticcheck's SA5002 (which meant who were using 100% CPU) by replacing the main for loop with a waitgroup
- Renamed a few errors across multiple packages, so these didn't shadow other errors and got a smaller scope
- Replaced the usage of `xerrors.Errorf` (deprecated in golang 1.13 with `fmt.Errorf`)
- Improved struct field alignment both for the `CARStore` and `dagTraversalRequest`
- Lowercased an error message and uppercased a package comment (not that these matter much I'd say)
- Replaced `ioutil` package usage (deprecated in golang 1.16) with the `io` package
- Checked `http.Write` errors
- Closed open sockets so there's a clean shutdown

Let me know if you think any of these changes are relevant and if I should break this down into multiple PRs. Thanks! :)