### PR TITLE
build: rename release artifacts to `saturn-L2-node`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,7 @@ builds:
     - goos: windows
       goarch: arm64
     main: ./cmd/saturn-l2
+    binary: saturn-L2-node
 
 archives:
   - replacements:


### PR DESCRIPTION
I feel the current name `L2-node` (or `L2-node.exe`) is not descriptive enough.

_As a user inspecting Process explorer/Activity monitor, I want to understand which process is the Saturn L2 Node._