### PR TITLE
L1 <-> L2 interop and better DDOS hardening

### DIFF
--- a/carstore/carstore.go
+++ b/carstore/carstore.go
@@ -43,7 +43,7 @@ var (
 	maxConcurrentReadyFetches = 3
 	secondMissDuration        = 24 * time.Hour
 	maxRecoverAttempts        = uint64(1)
-	defaultDownloadTimeout    = 20 * time.Minute
+	defaultDownloadTimeout    = 30 * time.Minute
 )
 
 var (
@@ -211,7 +211,7 @@ func (cs *CarStore) gcTraceLoop() {
 	}
 }
 
-func (cs *CarStore) Close() error {
+func (cs *CarStore) Stop() error {
 	log.Info("shutting down the carstore")
 	// Cancel the context
 	cs.cancel()

--- a/carstore/carstore_test.go
+++ b/carstore/carstore_test.go
@@ -88,7 +88,7 @@ func TestPersistentCache(t *testing.T) {
 		return err == nil
 	}, 50*time.Second, 200*time.Millisecond)
 
-	require.NoError(t, csh.cs.Close())
+	require.NoError(t, csh.cs.Stop())
 	require.EqualValues(t, 2*len(bz), csh.ms.nDownloaded())
 
 	csh.assertStorageStats(t, station.StorageStats{uint64(len(bz))})

--- a/carstore/gateway_api.go
+++ b/carstore/gateway_api.go
@@ -23,12 +23,17 @@ type GatewayAPI interface {
 var _ GatewayAPI = (*gatewayAPI)(nil)
 
 type gatewayAPI struct {
+	client  *http.Client
 	baseURL string
 	sApi    station.StationAPI
 }
 
 func NewGatewayAPI(baseURL string, sApi station.StationAPI) *gatewayAPI {
+	client := &http.Client{
+		Timeout: defaultDownloadTimeout,
+	}
 	return &gatewayAPI{
+		client:  client,
 		baseURL: baseURL,
 		sApi:    sApi,
 	}
@@ -43,7 +48,7 @@ func (g *gatewayAPI) Fetch(ctx context.Context, rootCID cid.Cid) (mount.Reader, 
 	q.Add("arg", rootCID.String())
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := g.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute http request")
 	}

--- a/carstore/gateway_api_test.go
+++ b/carstore/gateway_api_test.go
@@ -22,9 +22,7 @@ func TestGatewayAPI(t *testing.T) {
 	svc := testutils.GetTestServer(t, root, bz)
 	defer svc.Close()
 
-	gw := &gatewayAPI{
-		baseURL: svc.URL,
-	}
+	gw := NewGatewayAPI(svc.URL, nil)
 
 	c, err := cid.Decode(root)
 	require.NoError(t, err)
@@ -45,9 +43,7 @@ func TestGatewayAPIFailure(t *testing.T) {
 	defer svc.Close()
 
 	ctx := context.Background()
-	gw := &gatewayAPI{
-		baseURL: svc.URL,
-	}
+	gw := NewGatewayAPI(svc.URL, nil)
 
 	c, err := cid.Decode(root)
 	require.NoError(t, err)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -67,8 +67,8 @@ func main() {
 
 func mkRequestWithoutSelector(root cid.Cid) []byte {
 	req := types.CARTransferRequest{
-		Root:  base64.StdEncoding.EncodeToString(root.Bytes()),
-		ReqId: uuid.New().String(),
+		Root:      base64.StdEncoding.EncodeToString(root.Bytes()),
+		RequestId: uuid.New().String(),
 	}
 	reqBz, err := json.Marshal(req)
 	if err != nil {

--- a/cmd/saturn-l2/l1_discovery_test.go
+++ b/cmd/saturn-l2/l1_discovery_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	ip1 = "1.1.1.1"
+	ip2 = "2.2.2.2"
+	ip3 = "3.3.3.3"
+)
+
+func TestL1Discovery(t *testing.T) {
+	ctx := context.Background()
+	svc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ips := []string{ip1, ip2, ip3}
+		bz, _ := json.Marshal(ips)
+
+		w.Write(bz)
+	}))
+
+	cfg := config{
+		L1DiscoveryAPIUrl: svc.URL,
+		MaxL1Connections:  100,
+	}
+	l1s, err := getNearestL1s(ctx, cfg)
+	require.NoError(t, err)
+	require.Len(t, l1s, 3)
+
+	cfg.MaxL1Connections = 1
+	l1s, err = getNearestL1s(ctx, cfg)
+	require.NoError(t, err)
+	require.Len(t, l1s, 1)
+	require.EqualValues(t, ip1, l1s[0])
+}
+
+func TestL1DiscoveryFailure(t *testing.T) {
+	svc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("failure"))
+	}))
+
+	cfg := config{
+		L1DiscoveryAPIUrl: svc.URL,
+		MaxL1Connections:  100,
+	}
+	l1s, err := getNearestL1s(context.Background(), cfg)
+	require.Error(t, err)
+	require.Empty(t, l1s)
+}

--- a/cmd/saturn-l2/l2_id_persistence_test.go
+++ b/cmd/saturn-l2/l2_id_persistence_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestL2IdIsPersisted(t *testing.T) {
+	dir := t.TempDir()
+	id, err := readL2IdIfExists(dir)
+	require.Error(t, err)
+	require.EqualValues(t, uuid.UUID{}, id)
+
+	id, err = createAndPersistL2Id(dir)
+	require.NoError(t, err)
+	require.NotEqualValues(t, uuid.UUID{}, id)
+
+	id2, err := readL2IdIfExists(dir)
+	require.NoError(t, err)
+	require.EqualValues(t, id, id2)
+}

--- a/go.mod
+++ b/go.mod
@@ -22,10 +22,10 @@ require (
 	github.com/ipld/go-codec-dagpb v1.3.2 // indirect
 	github.com/ipld/go-ipld-prime v0.16.0
 	github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73
+	github.com/jpillora/backoff v1.0.0
 	github.com/libp2p/go-libp2p v0.19.2 // indirect
 	github.com/libp2p/go-libp2p-record v0.1.3 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0

--- a/l1interop/l1sseclient.go
+++ b/l1interop/l1sseclient.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	$END$
+}

--- a/l1interop/l1sseclient.go
+++ b/l1interop/l1sseclient.go
@@ -1,5 +1,261 @@
-package main
+package l1interop
 
-func main() {
-	$END$
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/saturn-l2/logs"
+
+	"github.com/filecoin-project/saturn-l2/types"
+
+	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/jpillora/backoff"
+)
+
+var (
+	// 5s, 7s, 11s, 16s, 25s, 38s, 1m, 1m30s, 2m, 3m, 7m, 10m, 10m, 10m, 10m
+	minBackOff           = 5 * time.Second
+	maxBackOff           = 10 * time.Minute
+	factor               = 1.5
+	maxReconnectAttempts = 15
+	maxPostResponseSize  = int64(102400) // 100 Kib
+
+	log = logging.Logger("l1-interop")
+)
+
+var (
+	l1RegisterURL = "https://%s/register/%s"
+	l1PostURL     = "https://%s/data/%s/%s"
+)
+
+type l1SseClient struct {
+	ctx     context.Context
+	cancelF context.CancelFunc
+
+	l1Addr string
+
+	client *http.Client
+	l2Id   string
+
+	minBackOffWait       time.Duration
+	maxBackoffWait       time.Duration
+	backOffFactor        float64
+	maxReconnectAttempts float64
+
+	cs     carServer
+	logger *logs.SaturnLogger
+
+	wg sync.WaitGroup
+
+	semaphore chan struct{}
+}
+
+type carServer interface {
+	ServeCARFile(ctx context.Context, dr *types.DagTraversalRequest, w io.Writer) error
+}
+
+func New(l2Id string, client *http.Client, logger *logs.SaturnLogger, cs carServer, l1Addr string, maxConcurrentReqs int) *l1SseClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &l1SseClient{
+		ctx:                  ctx,
+		cancelF:              cancel,
+		client:               client,
+		l2Id:                 l2Id,
+		minBackOffWait:       minBackOff,
+		maxBackoffWait:       maxBackOff,
+		backOffFactor:        factor,
+		maxReconnectAttempts: float64(maxReconnectAttempts),
+		logger:               logger,
+		cs:                   cs,
+		l1Addr:               l1Addr,
+		semaphore:            make(chan struct{}, maxConcurrentReqs),
+	}
+}
+
+func (l *l1SseClient) Start() error {
+	backoff := &backoff.Backoff{
+		Min:    l.minBackOffWait,
+		Max:    l.maxBackoffWait,
+		Factor: factor,
+		Jitter: true,
+	}
+
+	l1url := fmt.Sprintf(l1RegisterURL, l.l1Addr, l.l2Id)
+
+	for {
+		// if context has already been cancelled, return immediately
+		if l.ctx.Err() != nil {
+			return l.ctx.Err()
+		}
+
+		// construct an http register request to send to the L1 with the given context
+		req, err := http.NewRequest("GET", l1url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create http req: %w", err)
+		}
+		req = req.WithContext(l.ctx)
+
+		doBackOffFn := func() error {
+			// if we've exhausted the maximum number of connection attempts with the L1, return.
+			if backoff.Attempt() > l.maxReconnectAttempts {
+				log.Errorw("failed to connect to l1; exhausted max attempts", "l1", l.l1Addr, "err", err)
+				return fmt.Errorf("failed to connect to l1 after exhausting max attempts, l1: %s, err: %w", l.l1Addr, err)
+			}
+
+			// backoff and wait before making a new connection attempt to the L1.
+			duration := backoff.Duration()
+			bt := time.NewTimer(duration)
+			defer bt.Stop()
+			select {
+			case <-bt.C:
+				log.Infow("back-off complete, retrying http register request to l1",
+					"backoff time", duration.String(), "l1 Addr", l.l1Addr)
+			case <-l.ctx.Done():
+				log.Errorw("did not retry http request: context cancelled", "err", l.ctx.Err(), "l1", l.l1Addr)
+				return l.ctx.Err()
+			}
+			return nil
+		}
+
+		// make an http connection with keep alive
+		resp, err := l.client.Do(req)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return l.ctx.Err()
+			}
+			log.Errorw("failed to send register request to l1; will backoff and retry", "l1", l.l1Addr, "err", err)
+
+			if err := doBackOffFn(); err != nil {
+				return err
+			}
+			continue
+		}
+		defer resp.Body.Close()
+
+		// return immediately if we got a 4xx response status code from the L1.
+		if resp.StatusCode/100 == 4 {
+			log.Errorw("http registration request to L1 failed with non-retryable status code; returning",
+				"status code", resp.StatusCode, "l1", l.l1Addr)
+			return fmt.Errorf("terminating http request: received %d response from L1", resp.StatusCode)
+		}
+
+		// if we got anything other than a 200 for the registration -> retry
+		if resp.StatusCode != http.StatusOK {
+			log.Errorw("http registration request to l1 got invalid status code; will backoff and retry registration",
+				"code", resp.StatusCode, "l1", l.l1Addr)
+			if err := doBackOffFn(); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// we've registered successfully -> reset the backoff counter
+		backoff.Reset()
+
+		log.Infow("successfully registered and connected with l1", "l1", l.l1Addr)
+
+		// we've successfully connected to the L1, start reading new line delimited json requests for CAR files
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			log.Infow("will try to acquire semaphore for l1 request", "l1", l.l1Addr)
+			select {
+			case l.semaphore <- struct{}{}:
+				log.Infow("successfully acquired semaphore for l1 request", "l1", l.l1Addr)
+			case <-l.ctx.Done():
+				return l.ctx.Err()
+			}
+
+			var carReq types.CARTransferRequest
+			reqJSON := scanner.Text()
+			if err := json.Unmarshal([]byte(reqJSON), &carReq); err != nil {
+				return fmt.Errorf("could not unmarshal l1 request: err=%w", err)
+			}
+
+			dr, err := carReq.ToDAGRequest()
+			if err != nil {
+				return fmt.Errorf("could not parse car transfer request,err=%w", err)
+			}
+
+			l.logger.Infow(dr.RequestId, "received CAR transfer request from L1", "l1", l.l1Addr, "req", dr)
+
+			l.wg.Add(1)
+			go func() {
+				defer l.wg.Done()
+				defer func() {
+					select {
+					case <-l.semaphore:
+						log.Infow("successfully relased semaphore for l1 request", "l1", l.l1Addr)
+					case <-l.ctx.Done():
+						return
+					}
+				}()
+
+				if err := l.sendCarResponse(l.ctx, l.l1Addr, dr); err != nil {
+					l.logger.Errorw(dr.RequestId, "failed to send CAR file to L1 using Post", "err", err, "L1", l.l1Addr)
+				}
+			}()
+		}
+
+		if err := scanner.Err(); err != nil {
+			log.Errorw("error while reading l1 requests; will reconnect and retry", "err", err)
+		}
+	}
+}
+
+func (l *l1SseClient) Stop() {
+	l.cancelF()
+	l.wg.Wait()
+}
+
+func (l *l1SseClient) Do() {
+
+}
+
+func (l *l1SseClient) sendCarResponse(ctx context.Context, l1Addr string, dr *types.DagTraversalRequest) error {
+	respUrl := fmt.Sprintf(l1PostURL, l1Addr, dr.Root.String(), dr.RequestId.String())
+
+	prd, pw := io.Pipe()
+	defer prd.Close()
+	defer pw.Close()
+
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		err := l.cs.ServeCARFile(ctx, dr, pw)
+		_ = pw.CloseWithError(err)
+	}()
+
+	req, err := http.NewRequest(http.MethodPost, respUrl, prd)
+	if err != nil {
+		_ = prd.CloseWithError(err)
+		return fmt.Errorf("failed to create http post request to send back car to L1: %w", err)
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := l.client.Do(req)
+	if err != nil {
+		_ = prd.CloseWithError(err)
+		return fmt.Errorf("failed to send http post request with CAR to L1: %w", err)
+	}
+	defer resp.Body.Close()
+	_ = prd.Close()
+
+	lr := io.LimitReader(resp.Body, maxPostResponseSize)
+	_, _ = io.Copy(ioutil.Discard, lr)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got status code %d from L1 for POST, expected %d", resp.StatusCode, http.StatusOK)
+	}
+
+	l.logger.Infow(dr.RequestId, "successfully sent CAR file to L1", "l1", l1Addr)
+	return nil
 }

--- a/l1interop/l1sseclient_test.go
+++ b/l1interop/l1sseclient_test.go
@@ -1,0 +1,352 @@
+package l1interop
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/saturn-l2/carstore"
+
+	"github.com/filecoin-project/saturn-l2/types"
+	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
+
+	"github.com/filecoin-project/saturn-l2/testutils"
+
+	"github.com/filecoin-project/saturn-l2/logs"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+func TestSingleL1Simple(t *testing.T) {
+	l2Id := uuid.New().String()
+
+	h := buildHarness(t, l2Id, 1)
+	h.Start()
+	defer h.Stop()
+
+	req := uuid.New()
+	h.sendReq(req, h.cid1, 0)
+
+	require.Eventually(t, func() bool {
+		return h.hasRecievedCAR(req.String(), h.cid1.String(), 0)
+	}, 5*time.Second, 200*time.Millisecond)
+
+}
+
+func TestL1ConcurrentRequests(t *testing.T) {
+	l2Id := uuid.New().String()
+
+	h := buildHarness(t, l2Id, 1)
+	h.Start()
+	defer h.Stop()
+
+	// send 50 requests and assert we get back 20 responses
+	var wg sync.WaitGroup
+	var reqs []string
+	for i := 0; i < 50; i++ {
+		req := uuid.New()
+		reqs = append(reqs, req.String())
+		var cid cid.Cid
+		if i%2 == 0 {
+			cid = h.cid1
+		} else {
+			cid = h.cid2
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.sendReq(req, cid, 0)
+		}()
+	}
+
+	wg.Wait()
+
+	require.Eventually(t, func() bool {
+		for i := 0; i < 50; i++ {
+			id := reqs[i]
+			var cid cid.Cid
+			if i%2 == 0 {
+				cid = h.cid1
+			} else {
+				cid = h.cid2
+			}
+
+			ok := h.hasRecievedCAR(id, cid.String(), 0)
+			if !ok {
+				return false
+			}
+
+		}
+		return true
+	}, 5*time.Second, 200*time.Millisecond)
+}
+
+func TestMultipleL1ConcurrentRequests(t *testing.T) {
+	l2Id := uuid.New().String()
+	nL1s := 2
+
+	h := buildHarness(t, l2Id, nL1s)
+	h.Start()
+	defer h.Stop()
+
+	// send 50 requests and assert we get back 20 responses
+	var wg sync.WaitGroup
+	var reqs []string
+	for i := 0; i < 50; i++ {
+		i := i
+		req := uuid.New()
+		reqs = append(reqs, req.String())
+		var cid cid.Cid
+		if i%2 == 0 {
+			cid = h.cid1
+		} else {
+			cid = h.cid2
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.sendReq(req, cid, i%nL1s)
+		}()
+	}
+
+	wg.Wait()
+
+	require.Eventually(t, func() bool {
+		for i := 0; i < 50; i++ {
+			id := reqs[i]
+			var cid cid.Cid
+			if i%2 == 0 {
+				cid = h.cid1
+			} else {
+				cid = h.cid2
+			}
+
+			ok := h.hasRecievedCAR(id, cid.String(), i%nL1s)
+			if !ok {
+				return false
+			}
+
+		}
+		return true
+	}, 10*time.Second, 200*time.Millisecond)
+
+}
+
+type l1State struct {
+	svc *httptest.Server
+
+	requests chan types.CARTransferRequest
+
+	mu       sync.Mutex
+	gotPosts map[string][]byte
+}
+
+type l1Harness struct {
+	cid1 cid.Cid
+	cid2 cid.Cid
+
+	emu             sync.Mutex
+	expectedContent map[string][]byte
+
+	t       *testing.T
+	ctx     context.Context
+	cancelF context.CancelFunc
+
+	mu        sync.Mutex
+	l1Clients map[int]*l1SseClient
+	l1s       map[int]*l1State
+}
+
+func (h *l1Harness) Start() {
+	for _, l1 := range h.l1s {
+		l1 := l1
+		l1.svc.StartTLS()
+	}
+
+	for _, l1Client := range h.l1Clients {
+		l1Client := l1Client
+		go l1Client.Start()
+	}
+}
+
+func (h *l1Harness) Stop() {
+	h.cancelF()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, l1 := range h.l1s {
+		l1 := l1
+		l1.svc.Close()
+	}
+
+	for _, l1Client := range h.l1Clients {
+		l1Client := l1Client
+		l1Client.Stop()
+	}
+}
+
+func (h *l1Harness) hasRecievedCAR(reqId string, root string, l1 int) bool {
+	h.mu.Lock()
+	l1S := h.l1s[l1]
+	l1S.mu.Lock()
+
+	actualBz, ok := l1S.gotPosts[root+reqId]
+	l1S.mu.Unlock()
+	h.mu.Unlock()
+	if !ok {
+		return false
+	}
+
+	h.emu.Lock()
+	expectedBz, ok := h.expectedContent[root]
+	h.emu.Unlock()
+	if !ok {
+		return false
+	}
+
+	return bytes.Equal(expectedBz, actualBz)
+}
+
+func (h *l1Harness) sendReq(reqId uuid.UUID, root cid.Cid, l1 int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	l1S := h.l1s[l1]
+
+	l1S.requests <- types.CARTransferRequest{
+		RequestId: reqId.String(),
+		Root:      root.String(),
+	}
+}
+
+func buildHarness(t *testing.T, l2Id string, nL1s int) *l1Harness {
+	hCtx, cancel := context.WithCancel(context.Background())
+	carFile1 := "../testdata/files/sample-v1.car"
+	rootcid1, bz1 := testutils.ParseCar(t, hCtx, carFile1)
+	carFile2 := "../testdata/files/sample-rw-bs-v2.car"
+	rootcid2, bz2 := testutils.ParseCar(t, hCtx, carFile2)
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{
+		Transport: tr,
+	}
+	lg := logs.NewSaturnLogger()
+
+	h := &l1Harness{
+		cancelF:         cancel,
+		cid1:            rootcid1,
+		cid2:            rootcid2,
+		ctx:             hCtx,
+		t:               t,
+		expectedContent: make(map[string][]byte),
+		l1s:             make(map[int]*l1State),
+		l1Clients:       make(map[int]*l1SseClient),
+	}
+	h.expectedContent[rootcid1.String()] = bz1
+	h.expectedContent[rootcid2.String()] = bz2
+	ms := newMockCarServer(t, hCtx)
+
+	// Build the L1 HTTP Server
+	for i := 0; i < nL1s; i++ {
+		l1 := &l1State{
+			gotPosts: make(map[string][]byte),
+			requests: make(chan types.CARTransferRequest, 100),
+		}
+
+		mu := mux.NewRouter()
+		mu.HandleFunc("/data/{root}/{requestId}", func(w http.ResponseWriter, r *http.Request) {
+			vars := mux.Vars(r)
+			rootCid := vars["root"]
+			requestId := vars["requestId"]
+			bz, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				return
+			}
+			r.Body.Close()
+			l1.mu.Lock()
+			l1.gotPosts[rootCid+requestId] = bz
+			l1.mu.Unlock()
+		})
+
+		mu.HandleFunc("/register/{l2Id}", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			vars := mux.Vars(r)
+			l2Idr := vars["l2Id"]
+			if l2Idr != l2Id {
+				return
+			}
+			for {
+				select {
+				case cr := <-l1.requests:
+					bz, err := json.Marshal(cr)
+					if err != nil {
+						return
+					}
+					w.Write(bz)
+					w.Write([]byte("\n"))
+					if f, ok := w.(http.Flusher); ok {
+						f.Flush()
+					}
+				case <-hCtx.Done():
+					return
+				}
+			}
+		})
+
+		svc := httptest.NewUnstartedServer(mu)
+		l1.svc = svc
+
+		h.l1Clients[i] = New(l2Id, client, lg, ms, svc.Listener.Addr().String(), 3)
+		h.l1s[i] = l1
+	}
+
+	return h
+}
+
+type mockCarServer struct {
+	cars map[string][]byte
+}
+
+func newMockCarServer(t *testing.T, ctx context.Context) *mockCarServer {
+	carFile1 := "../testdata/files/sample-v1.car"
+	rootcid1, bz1 := testutils.ParseCar(t, ctx, carFile1)
+	carFile2 := "../testdata/files/sample-rw-bs-v2.car"
+	rootcid2, bz2 := testutils.ParseCar(t, ctx, carFile2)
+
+	m := make(map[string][]byte)
+
+	m[rootcid1.String()] = bz1
+	m[rootcid2.String()] = bz2
+
+	return &mockCarServer{
+		cars: m,
+	}
+}
+
+func (mc *mockCarServer) ServeCARFile(ctx context.Context, dr *types.DagTraversalRequest, w io.Writer) error {
+	r := dr.Root.String()
+
+	bz, ok := mc.cars[r]
+	if !ok {
+		return carstore.ErrNotFound
+	}
+	w.Write(bz)
+	return nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"bytes"
-	"encoding/base64"
 	"fmt"
 
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
@@ -11,68 +9,41 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/dagcbor"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 )
 
 // CARTransferRequest is the request sent by the client to transfer a CAR file
 // for the given root and selector.
 type CARTransferRequest struct {
-	ReqId      string
-	Root       string // base64 encoded byte array
-	Selector   string // base 64 encoded byte array
+	RequestId  string
+	Root       string
 	SkipOffset uint64
 }
 
 func (c *CARTransferRequest) ToDAGRequest() (*DagTraversalRequest, error) {
-	rootbz, err := base64.StdEncoding.DecodeString(c.Root)
+	rootCid, err := cid.Decode(c.Root)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode root: %s", err)
-	}
-	rootcid, err := cid.Cast(rootbz)
-	if err != nil {
-		return nil, fmt.Errorf("failed to cast root to cid: %s", err)
+		return nil, fmt.Errorf("failed to parse cid: %w", err)
 	}
 
-	var sel ipld.Node
-	if c.Selector != "" {
-		selbz, err := base64.StdEncoding.DecodeString(c.Selector)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode selector: %s", err)
-		}
-		sel, err = decodeSelector(selbz)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode selector to ipld node: %s", err)
-		}
-	} else {
-		// use the default "select all" selector.
-		sel = selectorparse.CommonSelector_ExploreAllRecursively
-	}
+	// use the default "select all" selector for now.
+	sel := selectorparse.CommonSelector_ExploreAllRecursively
 
-	reqId, err := uuid.Parse(c.ReqId)
+	reqId, err := uuid.Parse(c.RequestId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse uuid: %w", err)
 	}
 
 	return &DagTraversalRequest{
-		ReqId:    reqId,
-		Root:     rootcid,
-		Selector: sel,
-		Skip:     c.SkipOffset,
+		RequestId:  reqId,
+		Root:       rootCid,
+		Selector:   sel,
+		SkipOffset: c.SkipOffset,
 	}, nil
 }
 
 type DagTraversalRequest struct {
-	ReqId    uuid.UUID
-	Root     cid.Cid
-	Selector ipld.Node
-	Skip     uint64
-}
-
-func decodeSelector(sel []byte) (ipld.Node, error) {
-	nb := basicnode.Prototype.Any.NewBuilder()
-	if err := dagcbor.Decode(nb, bytes.NewReader(sel)); err != nil {
-		return nil, err
-	}
-	return nb.Build(), nil
+	RequestId  uuid.UUID
+	Root       cid.Cid
+	SkipOffset uint64
+	Selector   ipld.Node
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+var root = "QmfMYyn8LUWEfRXfijKFjBAshSsPVRUgwLZzsD7kcTtX1A"
+
+func TestCarTransferRequest(t *testing.T) {
+	c, err := cid.Decode(root)
+	require.NoError(t, err)
+
+	tcs := map[string]struct {
+		cr      CARTransferRequest
+		isError bool
+	}{
+		"invalid cid": {
+			cr: CARTransferRequest{
+				RequestId: uuid.New().String(),
+				Root:      "test",
+			},
+			isError: true,
+		},
+		"invalid uuid": {
+			cr: CARTransferRequest{
+				RequestId: "blah",
+				Root:      c.String(),
+			},
+			isError: true,
+		},
+		"valid request": {
+			cr: CARTransferRequest{
+				Root:      c.String(),
+				RequestId: uuid.New().String(),
+			},
+			isError: false,
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			dr, err := tc.cr.ToDAGRequest()
+			if tc.isError {
+				require.Error(t, err)
+				require.Nil(t, dr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, dr)
+				require.EqualValues(t, tc.cr.RequestId, dr.RequestId.String())
+				require.EqualValues(t, tc.cr.Root, dr.Root.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the interop for L1 <-> L2 and better DDOS hardening to L2s using timeouts, deadlines, limited buffer sizes for reading requests and responses and limiting the number of outgoing connections and the number of parallel requests processed.