### PR TITLE
Drain response before reconnecting

### DIFF
--- a/l1interop/l1sseclient.go
+++ b/l1interop/l1sseclient.go
@@ -91,7 +91,14 @@ func (l *l1SseClient) Start() error {
 
 	l1url := fmt.Sprintf(l1RegisterURL, l.l1Addr, l.l2Id)
 
+	var resp *http.Response
+
 	for {
+		if resp != nil && resp.Body != nil {
+			lr := io.LimitReader(resp.Body, maxPostResponseSize)
+			_, _ = io.Copy(io.Discard, lr)
+			resp.Body.Close()
+		}
 		// if context has already been cancelled, return immediately
 		if l.ctx.Err() != nil {
 			return l.ctx.Err()
@@ -127,7 +134,7 @@ func (l *l1SseClient) Start() error {
 		}
 
 		// make an http connection with keep alive
-		resp, err := l.client.Do(req)
+		resp, err = l.client.Do(req)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return l.ctx.Err()


### PR DESCRIPTION
Drain the L1 response on the registration API call before attempting a reconnect so the original connection get re-used if it's still available.