### PR TITLE
feat: improve logging for Station

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,21 +135,23 @@ At present, the L2 implementation has the following features:
 ```
 ./saturn-l2
 ...
-Server listening on 127.0.0.1:52860
 WebUI: http://localhost:52860/webui
+API: http://localhost:52860/
 ...
 ```
 
-When an L2 connects/disconnects with an L1 it will log the following at the INFO log level
+When an L2 connects/disconnects with an L1 it prints this to standard output:
 
 ```
-new L1 connection established {"l1": "127.0.0.1:59003", "nL1sConnected": 2}
-lost connection to L1 {"l1": "127.0.0.1:59003", "nL1sConnected": 1}
+INFO: Saturn Node is online and connected to 1 peer(s)
+INFO: Saturn Node is online and connected to 2 peer(s)
+INFO: Saturn Node is online and connected to 1 peer(s)
+ERROR: Saturn Node lost connection to the network
 ```
 
 If you want to connect to `WebUI`, also run `./scripts/download-webui.sh`.
 
-Note that the the Saturn L2 node only binds to the **localhost** loopback network interface and so will only be reachable from the same machine.
+Note that the Saturn L2 node only binds to the **localhost** loopback network interface and so will only be reachable from the same machine.
 In the above snippet, `52860` is the port that the Saturn L2 node binds to on the localhost interface. This port can be configured using the `PORT` environment variable as mentioned above.
 
 ### HTTP APIs

--- a/cmd/saturn-l2/main.go
+++ b/cmd/saturn-l2/main.go
@@ -280,8 +280,9 @@ func main() {
 	}
 
 	port := nl.Addr().(*net.TCPAddr).Port
-	fmt.Println("Server listening on", nl.Addr())
+	log.Infof("Server listening on %v", nl.Addr())
 	fmt.Printf("WebUI: http://localhost:%d/webui\n", port)
+	fmt.Printf("API: http://localhost:%d/\n", port)
 
 	if err := srv.Serve(nl); err != http.ErrServerClosed {
 		fmt.Fprintf(os.Stderr, "error shutting down the server: %s", err.Error())
@@ -335,7 +336,7 @@ func mkConfig() (config, error) {
 	if _, err := os.Stat(rootDirStr); err != nil {
 		return config{}, fmt.Errorf("root dir %s does NOT exist", rootDirStr)
 	}
-	fmt.Printf("Using root dir %s\n", rootDirStr)
+	log.Infof("Using root dir %s\n", rootDirStr)
 
 	var l1IPAddrs L1IPAddrs
 	var useL1IPAddrs bool


### PR DESCRIPTION
Rework internal logs to use Zap.

Add two new log messages for the case when the node connects or disconnects from the network.

Add a new log to report the API server where the Station can find `/stats` endpoint.

```
WebUI: http://localhost:52860/webui
API: http://localhost:52746/
INFO: Saturn Node is online and connected to 1 peer(s)
INFO: Saturn Node is online and connected to 2 peer(s)
INFO: Saturn Node is online and connected to 1 peer(s)
ERROR: Saturn Node lost connection to the network
```

See https://github.com/filecoin-project/filecoin-station/issues/81