### PR TITLE
Log l1 activity

### DIFF
--- a/l1interop/l1sseclient.go
+++ b/l1interop/l1sseclient.go
@@ -28,7 +28,7 @@ var (
 	minBackOff           = 5 * time.Second
 	maxBackOff           = 10 * time.Minute
 	factor               = 1.5
-	maxReconnectAttempts = 2
+	maxReconnectAttempts = 15
 	maxPostResponseSize  = int64(102400) // 100 Kib
 
 	log = logging.Logger("l1-interop")

--- a/l1interop/l1sseclient_test.go
+++ b/l1interop/l1sseclient_test.go
@@ -188,7 +188,7 @@ func (h *l1Harness) Start() {
 
 	for _, l1Client := range h.l1Clients {
 		l1Client := l1Client
-		go l1Client.Start(h.nL1sConnected, make(chan struct{}), make(chan struct{}))
+		go l1Client.Start(h.nL1sConnected)
 	}
 }
 

--- a/l1interop/l1sseclient_test.go
+++ b/l1interop/l1sseclient_test.go
@@ -188,7 +188,7 @@ func (h *l1Harness) Start() {
 
 	for _, l1Client := range h.l1Clients {
 		l1Client := l1Client
-		go l1Client.Start(h.nL1sConnected)
+		go l1Client.Start(h.nL1sConnected, make(chan struct{}), make(chan struct{}))
 	}
 }
 
@@ -281,10 +281,13 @@ func buildHarness(t *testing.T, l2Id string, nL1s int) *l1Harness {
 		}
 
 		mu := mux.NewRouter()
-		mu.HandleFunc("/data/{root}/{requestId}", func(w http.ResponseWriter, r *http.Request) {
+		mu.HandleFunc("/data/{root}", func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
 			rootCid := vars["root"]
-			requestId := vars["requestId"]
+
+			vs := r.URL.Query()
+			requestId := vs.Get("requestId")
+
 			bz, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				return

--- a/types/types.go
+++ b/types/types.go
@@ -15,7 +15,7 @@ import (
 // for the given root and selector.
 type CARTransferRequest struct {
 	RequestId  string
-	Root       string `json:"cid"`
+	Root       string
 	SkipOffset uint64
 }
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -50,7 +50,7 @@ func TestCarTransferRequest(t *testing.T) {
 
 			var cr CARTransferRequest
 			require.NoError(t, json.Unmarshal(bz, &cr))
-			require.EqualValues(t, cr.Root, tc.cr)
+			require.EqualValues(t, cr.Root, tc.cr.Root)
 
 			dr, err := tc.cr.ToDAGRequest()
 			if tc.isError {


### PR DESCRIPTION
Closes #63 .

- Sends `requestId` as query param in the POST request to L1s.
- Create the L2 home directory if it does NOT exist.