### PR TITLE
Update download-webui.sh script to follow redirects

### DIFF
--- a/scripts/download-webui.sh
+++ b/scripts/download-webui.sh
@@ -7,7 +7,7 @@ echo "⇣ Downloading webui dist to $OUTDIR ⇣"
 mkdir -p $OUTDIR
 
 # Downloads latest release
-url=$(curl -s https://api.github.com/repos/filecoin-saturn/node-webui/releases/latest | \
+url=$(curl -L -s https://api.github.com/repos/filecoin-saturn/node-webui/releases/latest | \
     jq -r '.assets[] | select(.name|match("saturn-webui.tar.gz$")) | .browser_download_url')
 
 curl -L $url | tar -zx -C $OUTDIR


### PR DESCRIPTION
Add `-L` flag to `curl` command in `download-webui.sh` script so it works out of the box.

Current behavior without flag:
```
✗ curl -s https://api.github.com/repos/filecoin-saturn/node-webui/releases/latest
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/498078127/releases/latest",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```