### PR TITLE
Remove min disk space requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ At present, the L2 implementation has the following features:
    3. `MAX_L2_DISK_SPACE`
        MAX_L2_DISK_SPACE is the environment variable that determines the maximum disk space the L2 node
        can use to store cached CAR files. If this env variable is not configured, it defaults to 200GiB.
-       Note: The configured value should be greater than or equal to 200Gib.
+       Note: For efficient operation, the configured value should be greater than or equal to 200Gib.
 
    4. `FIL_WALLET_ADDRESS`
        FIL_WALLET_ADDRESS is the environment variable that determines the Filecoin wallet address of the L2 user.

--- a/cmd/saturn-l2/main.go
+++ b/cmd/saturn-l2/main.go
@@ -410,9 +410,6 @@ func mkConfig() (config, error) {
 	if err != nil {
 		return config{}, fmt.Errorf("failed to parse max disk space env var: %w", err)
 	}
-	if maxDiskSpace < defaultMaxDiskSpace {
-		return config{}, errors.New("max allocated disk space should be atleast 200GiB")
-	}
 
 	// parse root directory
 	rootDirStr, err := getRootDir()


### PR DESCRIPTION
For https://github.com/filecoin-station/core/issues/81

@aarshkshah1992 can we make it so the L2 can operate with less than 200Gib of disk space? With cloud servers, this amount of disk space is quite expensive.