### PR TITLE
Fix binary name for macOS releases

### DIFF
--- a/.gon.hcl
+++ b/.gon.hcl
@@ -1,4 +1,4 @@
-source = ["./dist/macos-x86-64_darwin_amd64_v1/L2-node"]
+source = ["./dist/macos-x86-64_darwin_amd64_v1/saturn-L2-node"]
 bundle_id = "io.filecoin.saturn.l2-node"
 
 apple_id {

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,7 @@ builds:
     goarch:
       - amd64
     main: ./cmd/saturn-l2
+    binary: saturn-L2-node
 archives:
   - builds:
     - saturn


### PR DESCRIPTION
Before this change, macOS archive used `L2-node` as the binary name, while all other platforms used `saturn-L2-node` instead.

This commit fixes the problem by making macOS consistent with other platforms.

